### PR TITLE
Add a 'test' command to setup.py to run unittests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst test.py benchmark.py LICENSE
+include README.rst test.py benchmark.py LICENSE dist.py

--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,10 @@ and send me a pull request.
 
 Tests
 -----
-Tests are written using the Python `unittest` framework. All tests are in the
-``test.py`` file and can be run using::
+Tests are written using the Python `unittest` framework. All tests currently
+reside in the ``test.py`` file and can be run using the `distutils` script::
   
-  $ python -m unittest test.py
+  $ python setup.py test
 
 
 Bugs

--- a/dist.py
+++ b/dist.py
@@ -1,0 +1,90 @@
+# vim: filetype=python3 tabstop=2 expandtab
+
+# blowfish
+# Copyright (C) 2015 Jashandeep Sohi <jashandeep.s.sohi@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import sys
+import os.path
+from distutils.cmd import Command
+from distutils.errors import DistutilsOptionError
+
+class test(Command):
+  
+  command_name = "test"
+  description = "run unittests using built modules/packages"
+  user_options = [
+    ("start-dir=", "s", "directory to start discovery"),
+    ("pattern=", "p", "pattern to match test files"),
+    ("test-name=", "t", "load specific tests using a Python dotted name "
+                  "(e.g. pkg.module.Class.function)"),
+    ("buffer", "b", "buffer stdout and stderr during tests"),
+    ("catch", "c", "catch ctrl-C and display results so far"),
+    ("failfast", "f", "stop on first fail or error"),
+    ("exit", "e", "exit if any tests fail")
+  ]
+  boolean_options = ["buffer", "catch", "failfast", "exit"]
+  
+  def initialize_options(self):
+    self.start_dir = None
+    self.pattern = None
+    self.test_name = None
+    self.buffer = False
+    self.catch = False
+    self.failfast = False
+    self.exit = True
+    
+  def finalize_options(self):    
+    if self.test_name and (self.start_dir or self.pattern):
+      raise DistutilsOptionError(
+        "must supply either --start-dir/--pattern or --test-name, not both"
+      )
+    
+    if self.start_dir is None:
+      self.start_dir = "."
+    
+    if self.pattern is None:
+      self.pattern = "test*.py"
+      
+  def run(self):    
+    build = self.get_finalized_command("build")
+    build.run()
+    
+    if self.catch:
+      unittest.installHandler()
+    
+    sys.path.insert(0, os.path.abspath(build.build_lib))
+    
+    test_loader = unittest.defaultTestLoader
+    
+    if self.test_name:
+      tests = test_loader.loadTestsFromName(self.test_name, None)
+    else:
+      tests = test_loader.discover(self.start_dir, self.pattern)
+    
+    test_runner = unittest.TextTestRunner(
+      verbosity = self.verbose,
+      failfast = self.failfast,
+      buffer = self.buffer
+    )
+    
+    test_results = test_runner.run(tests)
+      
+    del sys.path[0]
+    
+    if self.exit and not test_results.wasSuccessful():
+      raise SystemExit()
+      

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import dist
+
 from blowfish import __version__
 from distutils.core import setup
 
@@ -43,4 +45,7 @@ if __name__ == "__main__":
      "Topic :: Security :: Cryptography",
      "Topic :: Software Development :: Libraries :: Python Modules",  
     ],
+    cmdclass = {
+      "test": dist.test
+    }
   )


### PR DESCRIPTION
Now tests can be run using the `distutils` script:
```
$ python setup.py test -vv
running test
running build_py
test_decrypt_block (test.Cipher) ... ok
test_encrypt_block (test.Cipher) ... ok
test_decrypt_block (test.CipherLittleEndian) ... ok
test_encrypt_block (test.CipherLittleEndian) ... ok
test_cbc_cts_mode (test.ModesOfOperation) ... ok
test_cbc_mode (test.ModesOfOperation) ... ok
test_cfb_mode (test.ModesOfOperation) ... ok
test_ctr_mode (test.ModesOfOperation) ... ok
test_ecb_cts_mode (test.ModesOfOperation) ... ok
test_ecb_mode (test.ModesOfOperation) ... ok
test_ofb_mode (test.ModesOfOperation) ... ok
test_pcbc_mode (test.ModesOfOperation) ... ok

----------------------------------------------------------------------
Ran 12 tests in 1.816s

OK
```